### PR TITLE
ignore the leading 'v' in the tag for the debian version

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -39,7 +39,7 @@ else
 fi
 
 # setup version identifier
-tag=$(git describe --abbrev=0 --tags)
+tag=$(git describe --abbrev=0 --tags | cut -b 2-) # ignore the leading 'v'
 sha=$(git rev-parse HEAD)
 
 if [ -z $tag -o -z $sha -o -z $timestamp ]; then 


### PR DESCRIPTION
Rebased version of @harrison-caudill #4.  lgtm.